### PR TITLE
fix: update burndown list with test suite improvements

### DIFF
--- a/burndown-blocklist.json
+++ b/burndown-blocklist.json
@@ -38,7 +38,6 @@
       "tests/unit/services/project-manifest.service.test.ts",
       "tests/unit/services/project-validation.service.test.ts",
       "tests/unit/services/template-identifier.service.test.ts",
-      "tests/unit/services/template-service.test.ts",
       "tests/unit/services/variable-substitution-service.test.ts"
     ]
   },
@@ -52,10 +51,10 @@
     }
   },
   "statistics": {
-    "totalTests": 851,
-    "passingTests": 474,
-    "failingTests": 376,
-    "blockedTestFiles": 35,
-    "passingTestFiles": 4
+    "totalTests": 892,
+    "passingTests": 533,
+    "failingTests": 358,
+    "blockedTestFiles": 34,
+    "passingTestFiles": 6
   }
 }


### PR DESCRIPTION
## Summary
Updates the burndown list to reflect the significant test suite improvements achieved in PR #77. This establishes the new baseline for continued progress tracking.

## Key Improvements Documented
- **Pass Rate**: 56% → 60% (+4% improvement)
- **Passing Tests**: 474 → 533 (+59 tests now passing)
- **Failing Tests**: 376 → 358 (-18 failures resolved)
- **Total Tests**: 851 → 892 (+41 new tests added)
- **Blocked Files**: 35 → 34 (1 file unblocked)

## Changes Made

### Burndown Blocklist Updates
- Removed `tests/unit/services/template-service.test.ts` from blocked list (now passing)
- Updated statistics to reflect current test state
- Reduced blocked test files from 35 to 34

### Progress Tracking
- Documented systematic improvements from service implementations
- Established accurate baseline for future burndown tracking
- Captured the impact of FileSystemService, TemplateService, and CompletionService fixes

## Verification
- ✅ Ran `npm run burndown:scan` to identify newly passing tests
- ✅ Verified statistics match actual test results (358 failed, 533 passed, 892 total)
- ✅ Confirmed burndown status shows 60% pass rate

## Impact
This update properly documents the technical debt reduction achieved while expanding test coverage. It provides an accurate foundation for continuing the systematic improvement of the test suite.

Related to: #56 (original test failures issue)
Follows up on: #77 (test improvements PR)

🤖 Generated with [Claude Code](https://claude.ai/code)