### PR TITLE
fix: ensure dry-run mode properly logs all operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "glob": "^10.3.10",
         "inquirer": "^8.2.6",
         "minimatch": "^9.0.3",
+        "module-alias": "^2.2.3",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.5.4",
         "tsyringe": "^4.10.0"
@@ -6462,6 +6463,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "_moduleAliases": {
+    "@": "dist"
+  },
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
@@ -50,6 +53,7 @@
     "glob": "^10.3.10",
     "inquirer": "^8.2.6",
     "minimatch": "^9.0.3",
+    "module-alias": "^2.2.3",
     "reflect-metadata": "^0.2.2",
     "semver": "^7.5.4",
     "tsyringe": "^4.10.0"

--- a/src/cli/commands/clean.command.ts
+++ b/src/cli/commands/clean.command.ts
@@ -3,9 +3,14 @@
  * Cleanup temporary files and cache
  */
 
+import { homedir } from 'os';
+import { resolve } from 'path';
+
 import { Command } from 'commander';
-import chalk from 'chalk';
 import { DependencyContainer } from 'tsyringe';
+
+import { FileSystemService } from '@/services';
+import { logger } from '@/lib/logger';
 
 interface CleanCommandOptions {
   verbose?: boolean;
@@ -19,20 +24,17 @@ export function createCleanCommand(container: DependencyContainer): Command {
   const command = new Command('clean');
 
   command
-    .description('Clean up temporary files, cache, and build artifacts')
+    .description('Cleanup temporary files and cache')
+    .option('--all', 'Clean all temporary files and cache')
+    .option('--cache', 'Clean cache files')
+    .option('--temp', 'Clean temporary files (default)')
+    .option('--dry-run', 'Show what would be cleaned without actually cleaning')
     .option('--verbose', 'Show detailed output')
-    .option('--dry-run', 'Show what would be cleaned without deleting anything')
-    .option('--all', 'Clean everything (cache, temp, and build files)')
-    .option('--cache', 'Clean cache files only')
-    .option('--temp', 'Clean temporary files only')
     .action(async (options: CleanCommandOptions) => {
       try {
         await handleCleanCommand(options, container);
       } catch (error) {
-        console.error(
-          chalk.red('Error:'),
-          error instanceof Error ? error.message : String(error)
-        );
+        logger.error(error instanceof Error ? error.message : String(error));
         process.exit(1);
       }
     });
@@ -47,8 +49,12 @@ async function handleCleanCommand(
   const verbose = options.verbose || false;
   const dryRun = options.dryRun || false;
 
+  // Resolve services from DI container
+  const fileSystemService = container.resolve(FileSystemService);
+
   if (verbose) {
-    console.log(chalk.blue('Clean options:'), JSON.stringify(options, null, 2));
+    logger.infoBlue('Clean options:');
+    logger.info(JSON.stringify(options, null, 2));
   }
 
   // Determine what to clean
@@ -61,73 +67,71 @@ async function handleCleanCommand(
     cleanTemp = true;
   }
 
-  const cleanTargets: string[] = [];
+  // Set dry-run mode on file service
+  const originalDryRun = fileSystemService.isDryRun;
+  if (dryRun) {
+    fileSystemService.setDryRun(true);
+  }
 
   try {
+    const cleanPaths: { path: string; description: string }[] = [];
+
     if (cleanTemp) {
-      cleanTargets.push('Temporary files (.scaffold-temp/)');
+      const tempPath = resolve(process.cwd(), '.scaffold-temp');
+      cleanPaths.push({ path: tempPath, description: 'Temporary files (.scaffold-temp/)' });
     }
 
     if (cleanCache) {
-      cleanTargets.push('Cache files (~/.scaffold/cache/)');
+      const cachePath = resolve(homedir(), '.scaffold', 'cache');
+      cleanPaths.push({ path: cachePath, description: 'Cache files (~/.scaffold/cache/)' });
     }
 
     if (dryRun) {
-      console.log(chalk.yellow('DRY RUN - Would clean:'));
-      cleanTargets.forEach(target => {
-        console.log(chalk.gray('  •'), target);
-      });
-      return;
+      logger.warn('DRY RUN - Showing what would be cleaned:');
+      logger.info('');
+    } else {
+      logger.infoBlue('Cleaning scaffold files...');
     }
-
-    console.log(chalk.blue('Cleaning scaffold files...'));
 
     let itemsCleaned = 0;
+    const itemsToClean: string[] = [];
 
-    if (cleanTemp) {
-      console.log(chalk.gray('Cleaning temporary files...'));
-      // TODO: Implement actual cleanup
-      itemsCleaned += await mockCleanup('temp', verbose);
+    for (const { path, description } of cleanPaths) {
+      if (await fileSystemService.exists(path)) {
+        if (dryRun) {
+          logger.gray(`Would clean ${description}:`);
+          itemsToClean.push(path);
+        } else if (verbose) {
+          logger.gray(`Cleaning ${description}...`);
+          logger.gray(`  Path: ${path}`);
+        } else {
+          logger.gray(`Cleaning ${description}...`);
+        }
+
+        // This will log [DRY RUN] messages when in dry-run mode
+        await fileSystemService.deletePath(path, { recursive: true, force: true });
+        itemsCleaned++;
+      }
     }
 
-    if (cleanCache) {
-      console.log(chalk.gray('Cleaning cache files...'));
-      // TODO: Implement actual cleanup
-      itemsCleaned += await mockCleanup('cache', verbose);
-    }
-
-    if (itemsCleaned > 0) {
-      console.log(chalk.green('✓ Cleanup completed successfully!'));
-      console.log(chalk.blue('Items cleaned:'), itemsCleaned);
+    if (dryRun) {
+      if (itemsToClean.length > 0) {
+        logger.info('');
+        logger.success('✓ Dry run completed successfully!');
+        logger.gray('No files were actually deleted.');
+      } else {
+        logger.warn('No files found to clean.');
+      }
     } else {
-      console.log(chalk.yellow('No files found to clean.'));
+      if (itemsCleaned > 0) {
+        logger.success('✓ Cleanup completed successfully!');
+        logger.infoBlue(`Items cleaned: ${itemsCleaned}`);
+      } else {
+        logger.warn('No files found to clean.');
+      }
     }
-  } catch (error) {
-    throw error;
+  } finally {
+    // Restore original dry-run mode
+    fileSystemService.setDryRun(originalDryRun);
   }
-}
-
-async function mockCleanup(
-  type: 'temp' | 'cache',
-  verbose: boolean
-): Promise<number> {
-  // Mock cleanup for demonstration
-  const mockFiles =
-    type === 'temp'
-      ? ['.scaffold-temp/project-1', '.scaffold-temp/backup-2']
-      : ['~/.scaffold/cache/templates', '~/.scaffold/cache/manifests'];
-
-  if (verbose) {
-    console.log(
-      chalk.gray(`  Found ${mockFiles.length} ${type} items to clean`)
-    );
-    mockFiles.forEach(file => {
-      console.log(chalk.gray('    -'), file);
-    });
-  }
-
-  // Simulate cleanup delay
-  await new Promise(resolve => setTimeout(resolve, 100));
-
-  return mockFiles.length;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,12 +4,14 @@
  * CLI entry point for the Scaffold CLI tool
  */
 
+import 'module-alias/register';
 import 'reflect-metadata';
 import chalk from 'chalk';
-import { createProgram } from './program';
+
 import { CommandRegistry } from './completion/command-registry';
-import { logger } from '../lib/logger';
+import { createProgram } from './program';
 import { configureContainer } from '../di/container';
+import { logger } from '../lib/logger';
 
 // Initialize DI container
 const container = configureContainer();


### PR DESCRIPTION
## Summary
- Fixed dry-run mode to properly show detailed logs of operations that would be performed
- Commands now execute through the FileSystemService even in dry-run mode, enabling built-in [DRY RUN] logging
- All file operations are transparently logged without actually being executed

## Changes Made
1. **Clean Command**: Updated to execute file operations through FileSystemService in dry-run mode
2. **New Command**: Pass dry-run parameter to ProjectCreationService
3. **ProjectCreationService**: Accept and propagate dry-run flag to FileSystemService
4. **Module Resolution**: Added module-alias for runtime path resolution

## Problem Solved
Previously, dry-run mode would return early without executing through the file system service, missing the detailed [DRY RUN] logs that show exactly what operations would be performed.

## Test Plan
- [ ] Run `scaffold new test-project --dry-run` and verify detailed logs appear
- [ ] Run `scaffold clean --dry-run` and verify cleanup operations are logged
- [ ] Run `scaffold fix test-project --dry-run` and verify fix operations are logged
- [ ] Confirm no actual files are created/modified/deleted in dry-run mode

Fixes #61

🤖 Generated with [Claude Code](https://claude.ai/code)