### PR TITLE
refactor: migrate all imports to use @ alias paradigm

### DIFF
--- a/src/cli/commands/clean.command.ts
+++ b/src/cli/commands/clean.command.ts
@@ -8,7 +8,7 @@ import { resolve } from 'path';
 
 import { Command } from 'commander';
 import { DependencyContainer } from 'tsyringe';
-import { ExitCode } from '../../constants/exit-codes';
+import { ExitCode } from '@/constants/exit-codes';
 
 import { FileSystemService } from '@/services';
 import { logger } from '@/lib/logger';

--- a/src/cli/commands/config.command.ts
+++ b/src/cli/commands/config.command.ts
@@ -6,7 +6,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { DependencyContainer } from 'tsyringe';
-import { ConfigurationService } from '../../services';
+import { ConfigurationService } from '@/services';
 
 interface ConfigCommandOptions {
   verbose?: boolean;

--- a/src/cli/commands/extend.command.ts
+++ b/src/cli/commands/extend.command.ts
@@ -17,7 +17,7 @@ import {
 } from '@/services';
 import { selectTemplates } from '@/cli/utils/template-selector';
 import { logger } from '@/lib/logger';
-import { ExitCode, exitWithCode } from '../../constants/exit-codes';
+import { ExitCode, exitWithCode } from '@/constants/exit-codes';
 
 interface ExtendCommandOptions {
   template?: string;

--- a/src/cli/commands/fix.command.ts
+++ b/src/cli/commands/fix.command.ts
@@ -16,7 +16,7 @@ import {
   TemplateService,
   FileSystemService,
 } from '@/services';
-import { ExitCode, exitWithCode } from '../../constants/exit-codes';
+import { ExitCode, exitWithCode } from '@/constants/exit-codes';
 
 interface FixCommandOptions {
   verbose?: boolean;

--- a/src/cli/commands/template.command.ts
+++ b/src/cli/commands/template.command.ts
@@ -7,12 +7,12 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { DependencyContainer } from 'tsyringe';
-import { TemplateService } from '../../services';
-import { TemplateIdentifierService } from '../../services/template-identifier-service';
-import { shortSHA } from '../../lib/sha';
-import type { Template } from '../../models';
+import { TemplateService } from '@/services';
+import { TemplateIdentifierService } from '@/services/template-identifier-service';
+import { shortSHA } from '@/lib/sha';
+import type { Template } from '@/models';
 import { logger } from '@/lib/logger';
-import { ExitCode, exitWithCode } from '../../constants/exit-codes';
+import { ExitCode, exitWithCode } from '@/constants/exit-codes';
 
 interface TemplateCommandOptions {
   verbose?: boolean;

--- a/src/cli/completion/complete.ts
+++ b/src/cli/completion/complete.ts
@@ -5,8 +5,8 @@
 
 import { Command } from 'commander';
 import { DependencyContainer } from 'tsyringe';
-import { CompletionService } from '../../services';
-import type { CompletionContext } from '../../models';
+import { CompletionService } from '@/services';
+import type { CompletionContext } from '@/models';
 
 interface CompleteCommandOptions {
   line?: string;

--- a/src/cli/completion/index.ts
+++ b/src/cli/completion/index.ts
@@ -5,11 +5,11 @@
 
 import { Command } from 'commander';
 import { DependencyContainer } from 'tsyringe';
-import { createInstallCommand } from './install';
-import { createUninstallCommand } from './uninstall';
-import { createStatusCommand } from './status';
-import { createScriptCommand } from './script';
-import { createCompleteCommand } from './complete';
+import { createInstallCommand } from '@/cli/completion/install';
+import { createUninstallCommand } from '@/cli/completion/uninstall';
+import { createStatusCommand } from '@/cli/completion/status';
+import { createScriptCommand } from '@/cli/completion/script';
+import { createCompleteCommand } from '@/cli/completion/complete';
 
 export function createCompletionCommand(container: DependencyContainer): Command {
   const command = new Command('completion');

--- a/src/cli/completion/install.ts
+++ b/src/cli/completion/install.ts
@@ -6,8 +6,8 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { DependencyContainer } from 'tsyringe';
-import { CompletionService } from '../../services';
-import { ShellType } from '../../models';
+import { CompletionService } from '@/services';
+import { ShellType } from '@/models';
 import { logger } from '@/lib/logger';
 
 interface InstallCommandOptions {

--- a/src/cli/completion/script.ts
+++ b/src/cli/completion/script.ts
@@ -6,8 +6,8 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { DependencyContainer } from 'tsyringe';
-import { CompletionService } from '../../services';
-import { ShellType } from '../../models';
+import { CompletionService } from '@/services';
+import { ShellType } from '@/models';
 import { logger } from '@/lib/logger';
 
 interface ScriptCommandOptions {

--- a/src/cli/completion/status.ts
+++ b/src/cli/completion/status.ts
@@ -7,9 +7,9 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { existsSync, statSync } from 'fs';
 import { DependencyContainer } from 'tsyringe';
-import { CompletionService } from '../../services';
-import { createLogger, logger } from '../../lib/logger';
-import type { CompletionConfig } from '../../models';
+import { CompletionService } from '@/services';
+import { createLogger, logger } from '@/lib/logger';
+import type { CompletionConfig } from '@/models';
 
 interface StatusCommandOptions {
   verbose?: boolean;

--- a/src/cli/completion/uninstall.ts
+++ b/src/cli/completion/uninstall.ts
@@ -6,7 +6,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { DependencyContainer } from 'tsyringe';
-import { CompletionService } from '../../services';
+import { CompletionService } from '@/services';
 import { logger } from '@/lib/logger';
 
 interface UninstallCommandOptions {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,10 +8,10 @@ import 'module-alias/register';
 import 'reflect-metadata';
 import chalk from 'chalk';
 
-import { CommandRegistry } from './completion/command-registry';
-import { createProgram } from './program';
-import { configureContainer } from '../di/container';
-import { logger } from '../lib/logger';
+import { CommandRegistry } from '@/cli/completion/command-registry';
+import { createProgram } from '@/cli/program';
+import { configureContainer } from '@/di/container';
+import { logger } from '@/lib/logger';
 
 // Initialize DI container
 const container = configureContainer();

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -9,15 +9,15 @@ import { join, dirname } from 'path';
 import { DependencyContainer } from 'tsyringe';
 
 // Import command handlers
-import { createNewCommand } from './commands/new.command';
-import { createTemplateCommand } from './commands/template.command';
-import { createCheckCommand } from './commands/check.command';
-import { createFixCommand } from './commands/fix.command';
-import { createExtendCommand } from './commands/extend.command';
-import { createShowCommand } from './commands/show.command';
-import { createConfigCommand } from './commands/config.command';
-import { createCleanCommand } from './commands/clean.command';
-import { createCompletionCommand } from './completion';
+import { createNewCommand } from '@/cli/commands/new.command';
+import { createTemplateCommand } from '@/cli/commands/template.command';
+import { createCheckCommand } from '@/cli/commands/check.command';
+import { createFixCommand } from '@/cli/commands/fix.command';
+import { createExtendCommand } from '@/cli/commands/extend.command';
+import { createShowCommand } from '@/cli/commands/show.command';
+import { createConfigCommand } from '@/cli/commands/config.command';
+import { createCleanCommand } from '@/cli/commands/clean.command';
+import { createCompletionCommand } from '@/cli/completion';
 
 export function createProgram(container: DependencyContainer): Command {
   // Get package.json for version info

--- a/src/cli/utils/template-selector.ts
+++ b/src/cli/utils/template-selector.ts
@@ -5,8 +5,8 @@
 
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import { TemplateService } from '../../services';
-import type { TemplateSummary } from '../../models';
+import { TemplateService } from '@/services';
+import type { TemplateSummary } from '@/models';
 import { logger } from '@/lib/logger';
 
 export interface TemplateSelectionOptions {

--- a/src/di/container.ts
+++ b/src/di/container.ts
@@ -1,20 +1,20 @@
 import 'reflect-metadata';
 import { container, DependencyContainer } from 'tsyringe';
 
-import { FileSystemService } from '../services/file-system.service';
-import { ConfigurationService } from '../services/configuration.service';
-import { TemplateIdentifierService } from '../services/template-identifier-service';
-import { VariableSubstitutionService } from '../services/variable-substitution.service';
-import { ProjectManifestService } from '../services/project-manifest.service';
-import { TemplateService } from '../services/template-service';
-import { ProjectCreationService } from '../services/project-creation.service';
-import { ProjectValidationService } from '../services/project-validation.service';
-import { ProjectFixService } from '../services/project-fix.service';
-import { ProjectExtensionService } from '../services/project-extension.service';
-import { CompletionService } from '../services/completion-service';
-import { FileCompletionProvider } from '../services/completion-providers/file-completion-provider';
-import { ProjectCompletionProvider } from '../services/completion-providers/project-completion-provider';
-import { TemplateCompletionProvider } from '../services/completion-providers/template-completion-provider';
+import { FileSystemService } from '@/services/file-system.service';
+import { ConfigurationService } from '@/services/configuration.service';
+import { TemplateIdentifierService } from '@/services/template-identifier-service';
+import { VariableSubstitutionService } from '@/services/variable-substitution.service';
+import { ProjectManifestService } from '@/services/project-manifest.service';
+import { TemplateService } from '@/services/template-service';
+import { ProjectCreationService } from '@/services/project-creation.service';
+import { ProjectValidationService } from '@/services/project-validation.service';
+import { ProjectFixService } from '@/services/project-fix.service';
+import { ProjectExtensionService } from '@/services/project-extension.service';
+import { CompletionService } from '@/services/completion-service';
+import { FileCompletionProvider } from '@/services/completion-providers/file-completion-provider';
+import { ProjectCompletionProvider } from '@/services/completion-providers/project-completion-provider';
+import { TemplateCompletionProvider } from '@/services/completion-providers/template-completion-provider';
 
 export function configureContainer(): DependencyContainer {
   // Phase 1: Core Services (no dependencies)

--- a/src/models/validation-report.ts
+++ b/src/models/validation-report.ts
@@ -2,7 +2,7 @@
  * Validation report data models and interfaces
  */
 
-import { RuleFix } from './template';
+import { RuleFix } from '@/models/template';
 
 export interface ValidationError {
   id: string;                    // Unique error identifier (UUID v4)

--- a/src/services/completion-providers/file-completion-provider.ts
+++ b/src/services/completion-providers/file-completion-provider.ts
@@ -5,7 +5,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { injectable } from 'tsyringe';
-import type { CompletionContext, CompletionItem } from '../../models';
+import type { CompletionContext, CompletionItem } from '@/models';
 
 export interface IFileCompletionProvider {
   /**

--- a/src/services/completion-providers/template-completion-provider.ts
+++ b/src/services/completion-providers/template-completion-provider.ts
@@ -3,8 +3,8 @@
  */
 
 import { injectable, inject } from 'tsyringe';
-import type { CompletionContext, CompletionItem } from '../../models';
-import { TemplateService } from '../template-service';
+import type { CompletionContext, CompletionItem } from '@/models';
+import { TemplateService } from '@/services/template-service';
 
 export interface ITemplateCompletionProvider {
   /**

--- a/src/services/completion-service.ts
+++ b/src/services/completion-service.ts
@@ -19,7 +19,7 @@ import type {
 } from '@/models';
 import { ShellType } from '@/models';
 
-import { TemplateService } from './template-service';
+import { TemplateService } from '@/services/template-service';
 
 export interface ICompletionService {
   /**

--- a/src/services/configuration.service.ts
+++ b/src/services/configuration.service.ts
@@ -11,8 +11,8 @@ import type {
   UserPreferences,
   PathConfiguration,
   DefaultSettings,
-} from '../models';
-import { ConfigLevel } from '../models';
+} from '@/models';
+import { ConfigLevel } from '@/models';
 
 export type ConfigScope = ConfigLevel;
 

--- a/src/services/identifier-service.ts
+++ b/src/services/identifier-service.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { injectable } from 'tsyringe';
-import { shortSHA, isValidSHA, findSHAByPrefix } from '../lib/sha';
+import { shortSHA, isValidSHA, findSHAByPrefix } from '@/lib/sha';
 
 /**
  * Interface for alias mapping storage

--- a/src/services/project-creation.service.ts
+++ b/src/services/project-creation.service.ts
@@ -12,12 +12,12 @@ import type {
   AppliedTemplate,
   HistoryEntry,
 } from '@/models';
-import type { IFileSystemService } from './file-system.service';
-import { FileSystemService } from './file-system.service';
-import type { ITemplateService } from './template-service';
-import { TemplateService } from './template-service';
-import type { IVariableSubstitutionService } from './variable-substitution.service';
-import { VariableSubstitutionService } from './variable-substitution.service';
+import type { IFileSystemService } from '@/services/file-system.service';
+import { FileSystemService } from '@/services/file-system.service';
+import type { ITemplateService } from '@/services/template-service';
+import { TemplateService } from '@/services/template-service';
+import type { IVariableSubstitutionService } from '@/services/variable-substitution.service';
+import { VariableSubstitutionService } from '@/services/variable-substitution.service';
 
 export interface IProjectCreationService {
   /**

--- a/src/services/project-extension.service.ts
+++ b/src/services/project-extension.service.ts
@@ -9,17 +9,17 @@ import type {
   Template,
   AppliedTemplate,
   HistoryEntry,
-} from '../models';
-import type { ITemplateService } from './template-service';
-import { TemplateService } from './template-service';
-import type { IFileSystemService } from './file-system.service';
-import { FileSystemService } from './file-system.service';
-import type { IVariableSubstitutionService } from './variable-substitution.service';
-import { VariableSubstitutionService } from './variable-substitution.service';
-import type { IProjectManifestService } from './project-manifest.service';
-import { ProjectManifestService } from './project-manifest.service';
-import type { IProjectValidationService } from './project-validation.service';
-import { ProjectValidationService } from './project-validation.service';
+} from '@/models';
+import type { ITemplateService } from '@/services/template-service';
+import { TemplateService } from '@/services/template-service';
+import type { IFileSystemService } from '@/services/file-system.service';
+import { FileSystemService } from '@/services/file-system.service';
+import type { IVariableSubstitutionService } from '@/services/variable-substitution.service';
+import { VariableSubstitutionService } from '@/services/variable-substitution.service';
+import type { IProjectManifestService } from '@/services/project-manifest.service';
+import { ProjectManifestService } from '@/services/project-manifest.service';
+import type { IProjectValidationService } from '@/services/project-validation.service';
+import { ProjectValidationService } from '@/services/project-validation.service';
 
 export interface IProjectExtensionService {
   /**

--- a/src/services/project-fix.service.ts
+++ b/src/services/project-fix.service.ts
@@ -14,16 +14,16 @@ import type {
   HistoryEntry,
 } from '@/models';
 
-import type { IFileSystemService } from './file-system.service';
-import { FileSystemService } from './file-system.service';
-import type { IProjectManifestService } from './project-manifest.service';
-import { ProjectManifestService } from './project-manifest.service';
-import type { IProjectValidationService } from './project-validation.service';
-import { ProjectValidationService } from './project-validation.service';
-import type { ITemplateService } from './template-service';
-import { TemplateService } from './template-service';
-import type { IVariableSubstitutionService } from './variable-substitution.service';
-import { VariableSubstitutionService } from './variable-substitution.service';
+import type { IFileSystemService } from '@/services/file-system.service';
+import { FileSystemService } from '@/services/file-system.service';
+import type { IProjectManifestService } from '@/services/project-manifest.service';
+import { ProjectManifestService } from '@/services/project-manifest.service';
+import type { IProjectValidationService } from '@/services/project-validation.service';
+import { ProjectValidationService } from '@/services/project-validation.service';
+import type { ITemplateService } from '@/services/template-service';
+import { TemplateService } from '@/services/template-service';
+import type { IVariableSubstitutionService } from '@/services/variable-substitution.service';
+import { VariableSubstitutionService } from '@/services/variable-substitution.service';
 
 export interface IProjectFixService {
   /**

--- a/src/services/project-manifest.service.ts
+++ b/src/services/project-manifest.service.ts
@@ -9,8 +9,8 @@ import { injectable, inject } from 'tsyringe';
 import { logger } from '@/lib/logger';
 import type { ProjectManifest } from '@/models';
 
-import type { IFileSystemService } from './file-system.service';
-import { FileSystemService } from './file-system.service';
+import type { IFileSystemService } from '@/services/file-system.service';
+import { FileSystemService } from '@/services/file-system.service';
 
 export interface IProjectManifestService {
   /**

--- a/src/services/project-validation.service.ts
+++ b/src/services/project-validation.service.ts
@@ -11,16 +11,16 @@ import type {
   ValidationWarning,
   ValidationStats,
   ProjectManifest,
-} from '../models';
-import type { ITemplateService } from './template-service';
-import { TemplateService } from './template-service';
-import type { IFileSystemService } from './file-system.service';
-import { FileSystemService } from './file-system.service';
-import type { IVariableSubstitutionService } from './variable-substitution.service';
-import { VariableSubstitutionService } from './variable-substitution.service';
-import type { IProjectManifestService } from './project-manifest.service';
-import { ProjectManifestService } from './project-manifest.service';
-import { shortSHA } from '../lib/sha';
+} from '@/models';
+import type { ITemplateService } from '@/services/template-service';
+import { TemplateService } from '@/services/template-service';
+import type { IFileSystemService } from '@/services/file-system.service';
+import { FileSystemService } from '@/services/file-system.service';
+import type { IVariableSubstitutionService } from '@/services/variable-substitution.service';
+import { VariableSubstitutionService } from '@/services/variable-substitution.service';
+import type { IProjectManifestService } from '@/services/project-manifest.service';
+import { ProjectManifestService } from '@/services/project-manifest.service';
+import { shortSHA } from '@/lib/sha';
 
 export interface IProjectValidationService {
   /**

--- a/src/services/template-identifier-service.ts
+++ b/src/services/template-identifier-service.ts
@@ -6,9 +6,9 @@
 import * as path from 'path';
 import * as os from 'os';
 import { injectable } from 'tsyringe';
-import { IdentifierService } from './identifier-service';
-import { generateSHAFromObject } from '../lib/sha';
-import type { Template } from '../models';
+import { IdentifierService } from '@/services/identifier-service';
+import { generateSHAFromObject } from '@/lib/sha';
+import type { Template } from '@/models';
 
 /**
  * Service for managing template identifiers (SHAs and aliases)

--- a/src/services/template-service.ts
+++ b/src/services/template-service.ts
@@ -13,9 +13,9 @@ import type {
   TemplateLibrary,
   TemplateSummary,
   TemplateSource,
-} from '../models';
-import { TemplateIdentifierService } from './template-identifier-service';
-import { shortSHA, isValidSHA } from '../lib/sha';
+} from '@/models';
+import { TemplateIdentifierService } from '@/services/template-identifier-service';
+import { shortSHA, isValidSHA } from '@/lib/sha';
 
 export interface ITemplateService {
   /**

--- a/src/services/variable-substitution.service.ts
+++ b/src/services/variable-substitution.service.ts
@@ -4,10 +4,10 @@
 
 import { randomUUID } from 'crypto';
 import { injectable, inject } from 'tsyringe';
-import type { Template, ValidationResult } from '../models';
-import type { IFileSystemService } from './file-system.service';
-import { FileSystemService } from './file-system.service';
-import { enhanceError } from '../lib';
+import type { Template, ValidationResult } from '@/models';
+import type { IFileSystemService } from '@/services/file-system.service';
+import { FileSystemService } from '@/services/file-system.service';
+import { enhanceError } from '@/lib';
 
 export interface VariableSubstitutionOptions {
   preserveEscapes?: boolean;

--- a/tests/contract/commands/scaffold-check.test.ts
+++ b/tests/contract/commands/scaffold-check.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createCheckCommand } from '../../../src/cli/commands/check.command';
+import { createCheckCommand } from '@/cli/commands/check.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-clean.test.ts
+++ b/tests/contract/commands/scaffold-clean.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createCleanCommand } from '../../../src/cli/commands/clean.command';
+import { createCleanCommand } from '@/cli/commands/clean.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-config.test.ts
+++ b/tests/contract/commands/scaffold-config.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createConfigCommand } from '../../../src/cli/commands/config.command';
+import { createConfigCommand } from '@/cli/commands/config.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-extend.test.ts
+++ b/tests/contract/commands/scaffold-extend.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createExtendCommand } from '../../../src/cli/commands/extend.command';
+import { createExtendCommand } from '@/cli/commands/extend.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-fix.test.ts
+++ b/tests/contract/commands/scaffold-fix.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createFixCommand } from '../../../src/cli/commands/fix.command';
+import { createFixCommand } from '@/cli/commands/fix.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-new.test.ts
+++ b/tests/contract/commands/scaffold-new.test.ts
@@ -8,7 +8,7 @@ import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-show.test.ts
+++ b/tests/contract/commands/scaffold-show.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createShowCommand } from '../../../src/cli/commands/show.command';
+import { createShowCommand } from '@/cli/commands/show.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/contract/commands/scaffold-template.test.ts
+++ b/tests/contract/commands/scaffold-template.test.ts
@@ -3,12 +3,12 @@
  * Tests MUST fail initially as no implementation exists yet (TDD)
  */
 
-import { createTemplateCommand } from '../../../src/cli/commands/template.command';
+import { createTemplateCommand } from '@/cli/commands/template.command';
 import {
   createMockFileSystem,
   createMockConsole,
   CommandResult,
-} from '../../helpers/cli-helpers';
+} from '@tests/helpers/cli-helpers';
 import mockFs from 'mock-fs';
 import { Command } from 'commander';
 

--- a/tests/fakes/example.test.ts
+++ b/tests/fakes/example.test.ts
@@ -10,7 +10,7 @@ import {
   FakeFileSystemService,
   createAllFakes,
   resetAllFakes,
-} from './index';
+} from '@tests/fakes/index';
 
 describe('Fake Services Usage Examples', () => {
   describe('FakeTemplateService', () => {

--- a/tests/integration/cli/completion/complete.test.ts
+++ b/tests/integration/cli/completion/complete.test.ts
@@ -10,7 +10,7 @@ import {
   setupTestEnvironment,
   expectCLIResult,
   createShellEnv,
-} from './cli-test-helpers';
+} from '@tests/integration/cli/completion/cli-test-helpers';
 
 describe('scaffold completion complete (integration)', () => {
   let tempDir: string;

--- a/tests/integration/cli/completion/install.test.ts
+++ b/tests/integration/cli/completion/install.test.ts
@@ -12,7 +12,7 @@ import {
   createShellEnv,
   completionFileExists,
   isCompletionInShellConfig,
-} from './cli-test-helpers';
+} from '@tests/integration/cli/completion/cli-test-helpers';
 
 describe('scaffold completion install (integration)', () => {
   let tempDir: string;

--- a/tests/integration/cli/completion/script.test.ts
+++ b/tests/integration/cli/completion/script.test.ts
@@ -9,7 +9,7 @@ import {
   setupTestEnvironment,
   expectCLIResult,
   createShellEnv,
-} from './cli-test-helpers';
+} from '@tests/integration/cli/completion/cli-test-helpers';
 
 describe('scaffold completion script (integration)', () => {
   let tempDir: string;

--- a/tests/integration/cli/completion/status.test.ts
+++ b/tests/integration/cli/completion/status.test.ts
@@ -10,7 +10,7 @@ import {
   setupTestEnvironment,
   expectCLIResult,
   createShellEnv,
-} from './cli-test-helpers';
+} from '@tests/integration/cli/completion/cli-test-helpers';
 
 describe('scaffold completion status (integration)', () => {
   let tempDir: string;

--- a/tests/integration/cli/completion/uninstall.test.ts
+++ b/tests/integration/cli/completion/uninstall.test.ts
@@ -12,7 +12,7 @@ import {
   createShellEnv,
   completionFileExists,
   isCompletionInShellConfig,
-} from './cli-test-helpers';
+} from '@tests/integration/cli/completion/cli-test-helpers';
 
 describe('scaffold completion uninstall (integration)', () => {
   let tempDir: string;

--- a/tests/unit/cli/commands/fix.test.ts
+++ b/tests/unit/cli/commands/fix.test.ts
@@ -3,17 +3,17 @@
  * Tests option parsing, validation, flow control, and error handling
  */
 
-import { createFixCommand } from '../../../../src/cli/commands/fix.command';
+import { createFixCommand } from '@/cli/commands/fix.command';
 import {
   ProjectFixService,
   ProjectValidationService,
   ProjectManifestService,
   TemplateService,
   FileSystemService,
-} from '../../../../src/services';
+} from '@/services';
 import { Command } from 'commander';
 import { existsSync } from 'fs';
-import type { ProjectManifest, ValidationReport } from '../../../../src/models';
+import type { ProjectManifest, ValidationReport } from '@/models';
 
 // Mock dependencies
 jest.mock('../../../../src/services');

--- a/tests/unit/cli/commands/template.test.ts
+++ b/tests/unit/cli/commands/template.test.ts
@@ -3,14 +3,14 @@
  * Tests option parsing, validation, flow control, and error handling
  */
 
-import { createTemplateCommand } from '../../../../src/cli/commands/template.command';
+import { createTemplateCommand } from '@/cli/commands/template.command';
 import {
   TemplateService,
-} from '../../../../src/services';
-import { TemplateIdentifierService } from '../../../../src/services/template-identifier-service';
+} from '@/services';
+import { TemplateIdentifierService } from '@/services/template-identifier-service';
 import { Command } from 'commander';
 import inquirer from 'inquirer';
-import type { Template, TemplateLibrary, TemplateSummary } from '../../../../src/models';
+import type { Template, TemplateLibrary, TemplateSummary } from '@/models';
 
 // Mock dependencies
 jest.mock('../../../../src/services');

--- a/tests/unit/services/completion-service.test.ts
+++ b/tests/unit/services/completion-service.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as path from 'path';
-import { FakeFileSystemService } from '../../fakes/file-system.fake';
+import { FakeFileSystemService } from '@tests/fakes/file-system.fake';
 
 // Mock fs-extra module with fake service
 const fakeFileSystemService = new FakeFileSystemService();
@@ -34,12 +34,12 @@ jest.mock('os', () => ({
   homedir: jest.fn().mockReturnValue('/mock/home'),
 }));
 
-import { CompletionService } from '../../../src/services/completion-service';
+import { CompletionService } from '@/services/completion-service';
 import {
   ShellType,
   CompletionConfig,
   CompletionContext,
-} from '../../../src/models';
+} from '@/models';
 
 describe('CompletionService', () => {
   let service: CompletionService;

--- a/tests/unit/services/configuration.service.test.ts
+++ b/tests/unit/services/configuration.service.test.ts
@@ -4,14 +4,14 @@
 
 import * as path from 'path';
 import * as os from 'os';
-import { FakeConfigurationService, FakeFileSystemService } from '../../fakes';
-import { ConfigLevel } from '../../../src/models';
+import { FakeConfigurationService, FakeFileSystemService } from '@tests/fakes';
+import { ConfigLevel } from '@/models';
 import type {
   ScaffoldConfig,
   UserPreferences,
   PathConfiguration,
   DefaultSettings,
-} from '../../../src/models';
+} from '@/models';
 
 // Mock os module
 jest.mock('os', () => ({

--- a/tests/unit/services/file-system.service.test.ts
+++ b/tests/unit/services/file-system.service.test.ts
@@ -6,8 +6,8 @@
 import mockFs from 'mock-fs';
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { FileSystemService, type BackupInfo, type FileOperationOptions, type CopyOptions, type DeleteOptions, type JsonWriteOptions } from '../../../src/services/file-system.service';
-import { createMockConsole } from '../../helpers/test-utils';
+import { FileSystemService, type BackupInfo, type FileOperationOptions, type CopyOptions, type DeleteOptions, type JsonWriteOptions } from '@/services/file-system.service';
+import { createMockConsole } from '@tests/helpers/test-utils';
 
 describe('FileSystemService', () => {
   let fileSystemService: FileSystemService;

--- a/tests/unit/services/project-creation.service.test.ts
+++ b/tests/unit/services/project-creation.service.test.ts
@@ -2,12 +2,12 @@
  * Unit tests for ProjectCreationService
  */
 
-import { ProjectCreationService } from '../../../src/services/project-creation.service';
-import type { Template } from '../../../src/models';
+import { ProjectCreationService } from '@/services/project-creation.service';
+import type { Template } from '@/models';
 import {
   FakeTemplateService,
   FakeFileSystemService,
-} from '../../fakes';
+} from '@tests/fakes';
 
 describe('ProjectCreationService', () => {
   let creationService: ProjectCreationService;

--- a/tests/unit/services/project-extension.service.test.ts
+++ b/tests/unit/services/project-extension.service.test.ts
@@ -2,11 +2,11 @@
  * Unit tests for ProjectExtensionService
  */
 
-import { ProjectExtensionService } from '../../../src/services/project-extension.service';
-import type { Template, ProjectManifest } from '../../../src/models';
-import { FakeTemplateService } from '../../fakes/template-service.fake';
-import { FakeFileSystemService } from '../../fakes/file-system.fake';
-import { FakeProjectManifestService } from '../../fakes/project-manifest.fake';
+import { ProjectExtensionService } from '@/services/project-extension.service';
+import type { Template, ProjectManifest } from '@/models';
+import { FakeTemplateService } from '@tests/fakes/template-service.fake';
+import { FakeFileSystemService } from '@tests/fakes/file-system.fake';
+import { FakeProjectManifestService } from '@tests/fakes/project-manifest.fake';
 
 describe('ProjectExtensionService', () => {
   let extensionService: ProjectExtensionService;

--- a/tests/unit/services/project-fix.service.test.ts
+++ b/tests/unit/services/project-fix.service.test.ts
@@ -2,16 +2,16 @@
  * Unit tests for ProjectFixService
  */
 
-import { ProjectFixService } from '../../../src/services/project-fix.service';
+import { ProjectFixService } from '@/services/project-fix.service';
 import type {
   Template,
   ProjectManifest,
   ValidationReport,
-} from '../../../src/models';
-import { FakeTemplateService } from '../../fakes/template-service.fake';
-import { FakeFileSystemService } from '../../fakes/file-system.fake';
-import { FakeProjectValidationService } from '../../fakes/project-validation.fake';
-import { FakeProjectManifestService } from '../../fakes/project-manifest.fake';
+} from '@/models';
+import { FakeTemplateService } from '@tests/fakes/template-service.fake';
+import { FakeFileSystemService } from '@tests/fakes/file-system.fake';
+import { FakeProjectValidationService } from '@tests/fakes/project-validation.fake';
+import { FakeProjectManifestService } from '@tests/fakes/project-manifest.fake';
 
 describe('ProjectFixService', () => {
   let fixService: ProjectFixService;

--- a/tests/unit/services/project-manifest.service.test.ts
+++ b/tests/unit/services/project-manifest.service.test.ts
@@ -2,11 +2,11 @@
  * Unit tests for ProjectManifestService
  */
 
-import { ProjectManifestService } from '../../../src/services/project-manifest.service';
-import type { ProjectManifest } from '../../../src/models';
+import { ProjectManifestService } from '@/services/project-manifest.service';
+import type { ProjectManifest } from '@/models';
 import {
   FakeFileSystemService,
-} from '../../fakes';
+} from '@tests/fakes';
 
 describe('ProjectManifestService', () => {
   let manifestService: ProjectManifestService;

--- a/tests/unit/services/project-validation.service.test.ts
+++ b/tests/unit/services/project-validation.service.test.ts
@@ -2,11 +2,11 @@
  * Unit tests for ProjectValidationService
  */
 
-import { ProjectValidationService } from '../../../src/services/project-validation.service';
-import type { Template, ProjectManifest } from '../../../src/models';
-import { FakeFileSystemService } from '../../fakes/file-system.fake';
-import { FakeTemplateService } from '../../fakes/template-service.fake';
-import { FakeProjectManifestService } from '../../fakes/project-manifest.fake';
+import { ProjectValidationService } from '@/services/project-validation.service';
+import type { Template, ProjectManifest } from '@/models';
+import { FakeFileSystemService } from '@tests/fakes/file-system.fake';
+import { FakeTemplateService } from '@tests/fakes/template-service.fake';
+import { FakeProjectManifestService } from '@tests/fakes/project-manifest.fake';
 
 describe('ProjectValidationService', () => {
   let validationService: ProjectValidationService;

--- a/tests/unit/services/template-service.test.ts
+++ b/tests/unit/services/template-service.test.ts
@@ -3,16 +3,16 @@
  */
 
 import * as path from 'path';
-import { TemplateService } from '../../../src/services/template-service';
+import { TemplateService } from '@/services/template-service';
 import type {
   Template,
   TemplateLibrary,
   TemplateSummary,
-} from '../../../src/models';
+} from '@/models';
 import {
   createMockImplementation,
   assertDefined,
-} from '../../helpers/test-utils';
+} from '@tests/helpers/test-utils';
 
 // Mock fs-extra with manual implementation
 jest.mock('fs-extra');

--- a/tests/unit/services/variable-substitution-service.test.ts
+++ b/tests/unit/services/variable-substitution-service.test.ts
@@ -5,7 +5,7 @@
 import {
   VariableSubstitutionService,
   type VariableSubstitutionOptions,
-} from '../../../src/services/variable-substitution.service';
+} from '@/services/variable-substitution.service';
 
 describe('VariableSubstitutionService', () => {
   let service: VariableSubstitutionService;


### PR DESCRIPTION
## Summary
- Migrated all relative imports to use absolute imports with @ alias
- Updated 55 files to use consistent import patterns
- Import restrictions are enforced via ESLint precommit hooks

## Changes
- **Source files**: All imports now use `@/` prefix instead of relative paths
- **Test files**: All imports use `@/` for source code and `@tests/` for test utilities
- **ESLint enforcement**: The `no-restricted-imports` rule blocks relative parent imports

## Benefits
✅ Makes imports consistent and predictable across the codebase
✅ Eliminates brittle relative path calculations (no more `../../../`)
✅ Simplifies refactoring and file moves
✅ Enforces import standards automatically via precommit hooks

## Configuration
- TypeScript path mappings already configured in `tsconfig.json` and `tsconfig.test.json`
- ESLint rule configured in `.eslintrc.burndown.js` to restrict relative imports
- Precommit hook runs ESLint to enforce import standards

## Test Plan
- [x] All imports updated to use @ alias
- [x] ESLint rule blocks relative parent imports
- [x] Precommit hook enforces import restrictions
- [ ] Build and tests pass with new imports

🤖 Generated with [Claude Code](https://claude.ai/code)