### PR TITLE
fix: remove empty line within import group in completion-service.ts

### DIFF
--- a/src/services/completion-service.ts
+++ b/src/services/completion-service.ts
@@ -18,7 +18,6 @@ import type {
   ShellCompletionScript,
 } from '@/models';
 import { ShellType } from '@/models';
-
 import { TemplateService } from '@/services/template-service';
 
 export interface ICompletionService {
@@ -208,7 +207,8 @@ export class CompletionService implements ICompletionService {
         const config = (await fs.readJson(configPath)) as CompletionConfig;
 
         // Check if script file still exists
-        const scriptExists = config.installPath && await fs.pathExists(config.installPath);
+        const scriptExists =
+          config.installPath && (await fs.pathExists(config.installPath));
 
         if (scriptExists) {
           return { ...config, isInstalled: true };
@@ -733,9 +733,9 @@ complete -c scaffold -f -a "(__scaffold_complete)"
       // For template delete/export, we should provide template name completions
       // Import the template provider to get template names
       // Dynamic imports needed for completion providers
-      const {
-        TemplateCompletionProvider,
-      } = await import('./completion-providers/template-completion-provider');
+      const { TemplateCompletionProvider } = await import(
+        './completion-providers/template-completion-provider'
+      );
       const templateProvider = new TemplateCompletionProvider(
         this.templateService
       );


### PR DESCRIPTION
## Summary
- Fixed ESLint import/order error at line 20 in `src/services/completion-service.ts`
- Removed unnecessary empty line between imports from the same module group (`@/models` and `@/services`)
- No new lint errors, test failures, or compilation errors introduced

## Test plan
- [x] Verified lint error is resolved by running `npx eslint src/services/completion-service.ts`
- [x] Confirmed tracking files show no new issues with `git diff main...HEAD tracking/*.json`
- [x] Pre-commit hooks passed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)